### PR TITLE
Misc: Correct casing of user parameter in user_in_custom_group method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+# v0.2.0
+
+BREAKING CHANGE (technically)
+
+- PersistentMessage.user_in_custom_group `User` parameter has been
+  renamed to `user`. This will only affect you if you were calling
+  the method with keyword arguments.

--- a/persistent_messages/models.py
+++ b/persistent_messages/models.py
@@ -304,10 +304,10 @@ class PersistentMessage(models.Model):
         self.display_until = None
         self.save()
 
-    def user_in_custom_group(self, User: settings.AUTH_USER_MODEL) -> bool:
+    def user_in_custom_group(self, user: settings.AUTH_USER_MODEL) -> bool:
         if not self.target_custom_group:
             return False
-        return settings.MESSAGE_CUSTOM_GROUPS[self.target_custom_group](User)
+        return settings.MESSAGE_CUSTOM_GROUPS[self.target_custom_group](user)
 
 
 class MessageDismissal(models.Model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-persistent-messages"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wrapper around django.contrib.messages adding persistence."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]


### PR DESCRIPTION
`User` implies it is the actual Django User model class being passed in, but in actuality it is an instance of the User model - this should be lowercase.