### PR TITLE
Upgrades

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -62,14 +62,12 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,13 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.5"
+    rev: "v0.2.1"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 # Persistent Messages-like Framework for Django
 
-Persisent, dismissable, targeted, messages framework for Django apps
+Persistent, dismissible, targeted, messages framework for Django apps
 
 ## STATUS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-persistent-messages"
-version = "0.3"
+version = "0.4"
 description = "Wrapper around django.contrib.messages adding persistence."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,11 +13,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -29,7 +27,7 @@ packages = [{ include = "persistent_messages" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0 || ^5.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{310}
-    django40-py{310}
-    django41-py{310,311}
     django42-py{310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py{312}
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff persistent_messages
+    ruff check persistent_messages
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Django 5.2 Compatibility Update
This PR updates the project to support Django 5.2 while making several other important improvements:
## Changes
1. Version bump: Increased package version from 0.3 to 0.4
2. Added support for Django 5.2
3. Deprecated support for Django versions before 4.2
4. Updated classifiers in pyproject.toml accordingly
5. Updated tox configuration to test against Django 4.2, 5.0, 5.2, and main
6. Ensured Django main branch is only tested on Python 3.12
7. Updated GitHub workflow to match the new test matrix

### Developer tooling:
1. Updated ruff configuration to use modern syntax structure (moved top-level settings to lint.* sections)
2. Updated ruff command to use modern ruff check syntax
3. Added ruff-format to pre-commit configuration
4. Updated ruff version from v0.1.5 to v0.2.1
